### PR TITLE
Makes gradle output in travis nicer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: java
 
+env:
+  global:
+    - TERM=dumb
+
 notifications:
   email: false


### PR DESCRIPTION
Informs gradle it is writing to a dumb terminal making the output
messages shown in travis human readable.

Before:
....

> Configuring > 0/1 projects > root project> Configuring > 0/1 projects > root project1/1 projects> Building 0% > :compileJavapileJava 
> Building 0%UP-TO-DATE
> Building 0%> Building 0%10% > :compileGroovy > Resolving dependencies ':compile'pileGroovy 
> Building 10%UP-TO-DATE
> Building 10%> Building 10%20% > :processResources> Building 20%UP-TO-DATE
> Building 20%> Building 20%30% > :classes> Building 30%UP-TO-DATE
> Building 30%> Building 30%40% > :compileTestJava > Resolving dependencies ':testCompile'pileTestJava
> Building 40% > :compileTestJava > Resolving dependencies ':testCompile'aven.org...
> Building 40% > :compileTestJava > Resolving dependencies ':testCompile' > 1 K2 K>...
> ...

After:
...
:compileJava UP-TO-DATE
:compileGroovy UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:compileTestJava
:compileTestGroovy
:processTestResources UP-TO-DATE
:testClasses
:test
:check 
