### PR TITLE
Always add Google and Android repositories

### DIFF
--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
@@ -130,15 +130,14 @@ class PackageResolver {
 
     log.debug "Found support library dependencies: $supportLibraryDeps"
 
+    project.repositories.maven {
+      url = androidRepositoryDir
+    }
+
     def needsDownload = false;
     if (!androidRepositoryDir.exists()) {
       needsDownload = true
       log.lifecycle 'Support library repository missing. Downloading...'
-
-      // Add future repository to the project since the main plugin skips it when missing.
-      project.repositories.maven {
-        url = androidRepositoryDir
-      }
     } else if (!dependenciesAvailable(supportLibraryDeps)) {
       needsDownload = true
       log.lifecycle 'Support library repository outdated. Downloading update...'
@@ -161,15 +160,14 @@ class PackageResolver {
 
     log.debug "Found Google Play Services dependencies: $playServicesDeps"
 
+    project.repositories.maven {
+      url = googleRepositoryDir
+    }
+
     def needsDownload = false;
     if (!googleRepositoryDir.exists()) {
       needsDownload = true
       log.lifecycle 'Google Play Services repository missing. Downloading...'
-
-      // Add future repository to the project since the main plugin skips it when missing.
-      project.repositories.maven {
-        url = googleRepositoryDir
-      }
     } else if (!dependenciesAvailable(playServicesDeps)) {
       needsDownload = true
       log.lifecycle 'Google Play Services repository outdated. Downloading update...'


### PR DESCRIPTION
Fix #23 
With version 0.10.0 of the Android Gradle plugin, the support libraries and the Play library were always marked as outdated, triggering the downloads at each build.

Turns out the Android Gradle plugin is not including the M2 repositories anymore, and the dependencies cannot be resolved.

Previously, we were adding the repos only if they were physically missing. This PR always adds the repositories anyway (unless no dependency).

Waiting for feedback!
