### PR TITLE
Fix missing method error

### DIFF
--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/System.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/System.groovy
@@ -3,12 +3,17 @@ package com.jakewharton.sdkmanager.internal;
 /** An indirection to {@link java.lang.System}. */
 interface System {
   String env(String name);
+  long nanoTime();
   String property(String key);
   String property(String key, String defaultValue);
 
   static final class Real implements System {
     @Override String env(String name) {
       return java.lang.System.getenv(name)
+    }
+
+    @Override long nanoTime() {
+      return java.lang.System.nanoTime();
     }
 
     @Override String property(String key) {


### PR DESCRIPTION
Currently gradle-plugin 0.10.0 throws error: 

No signature of method: static com.jakewharton.sdkmanager.internal.System.nanoTime() is applicable for argument types: () values: []
