### PR TITLE
Fix missing method error

### DIFF
--- a/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerPlugin.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerPlugin.groovy
@@ -41,9 +41,9 @@ class SdkManagerPlugin implements Plugin<Project> {
   }
 
   def time(String name, Closure task) {
-    long before = java.util.System.nanoTime()
+    long before = java.lang.System.nanoTime()
     task.run()
-    long after = java.util.System.nanoTime()
+    long after = java.lang.System.nanoTime()
     long took = TimeUnit.NANOSECONDS.toMillis(after - before)
     log.info "$name took $took ms."
   }


### PR DESCRIPTION
Currently gradle-plugin 0.10.0 throws error:

No signature of method: static com.jakewharton.sdkmanager.internal.System.nanoTime() is applicable for argument types: () values: []
