### PR TITLE
Update Android SDK version that is downloaded

### DIFF
--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/SdkDownload.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/SdkDownload.groovy
@@ -43,7 +43,7 @@ enum SdkDownload {
 
   /** Download the SDK to {@code temp} and extract to {@code dest}. */
   void download(File dest) {
-    def url = "http://dl.google.com/android/android-sdk_r22.6.2-$suffix.$ext"
+    def url = "http://dl.google.com/android/android-sdk_r23-$suffix.$ext"
     log.debug "Downloading SDK from $url."
 
     File temp = new File(dest.getParentFile(), 'android-sdk.temp')


### PR DESCRIPTION
This simply updates the download URL for the Android SDK to the latest one. This helps to fix some issues where specifying the latest build-tools (20.0.0) will not be recognized. This should also help with failure to get the latest version of other packages such as the support library repository.
