### PR TITLE
Refactor to allow overriding SDK version and url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 }
 
 group = 'com.jakewharton.sdkmanager'
-version = '0.12.1-SNAPSHOT'
+version = '0.12.2-SNAPSHOT'
 
 install {
   repositories.mavenInstaller {

--- a/src/acceptanceTest/groovy/com/jakewharton/sdkmanager/internal/SdkDownloadTest.groovy
+++ b/src/acceptanceTest/groovy/com/jakewharton/sdkmanager/internal/SdkDownloadTest.groovy
@@ -13,7 +13,7 @@ import static org.fest.assertions.api.Assertions.assertThat
 class SdkDownloadTest {
   @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> data() {
-    return SdkDownload.values().collect { [it] as Object[] }
+    return SdkPlatform.values().collect { [new SdkDownload(it)] as Object[] }
   }
 
   @Parameterized.Parameter
@@ -36,19 +36,19 @@ class SdkDownloadTest {
     def tools = new File(destination, FD_TOOLS)
     assertThat(tools).exists()
 
-    switch (sdkDownload) {
-      case SdkDownload.DARWIN:
-      case SdkDownload.LINUX:
+    switch (sdkDownload.platform) {
+      case SdkPlatform.DARWIN:
+      case SdkPlatform.LINUX:
         def android = new File(tools, 'android')
         assertThat(android).exists();
         assertThat(android.canExecute()).isTrue()
         break;
-      case SdkDownload.WINDOWS:
+      case SdkPlatform.WINDOWS:
         def android = new File(tools, 'android.bat')
         assertThat(android).exists()
         break;
       default:
-        throw new IllegalStateException("Unknown platform: " + sdkDownload);
+        throw new IllegalStateException("Unknown platform: " + sdkDownload.platform);
     }
   }
 }

--- a/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerExtension.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerExtension.groovy
@@ -3,4 +3,6 @@ package com.jakewharton.sdkmanager;
 class SdkManagerExtension {
   String emulatorVersion
   String emulatorArchitecture
+  String sdkVersion = '24.0.2'
+  String baseUrl = 'https://dl.google.com/android'
 }

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/Downloader.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/Downloader.groovy
@@ -2,10 +2,4 @@ package com.jakewharton.sdkmanager.internal
 
 interface Downloader {
   void download(File dest)
-
-  static final class Real implements Downloader {
-    @Override void download(File dest) {
-      SdkDownload.get().download(dest)
-    }
-  }
 }

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/SdkDownload.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/SdkDownload.groovy
@@ -5,47 +5,29 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.rauschig.jarchivelib.ArchiverFactory
 
-import static com.android.SdkConstants.PLATFORM_DARWIN
-import static com.android.SdkConstants.PLATFORM_LINUX
-import static com.android.SdkConstants.PLATFORM_WINDOWS
-import static com.android.SdkConstants.currentPlatform
 import static org.rauschig.jarchivelib.ArchiveFormat.TAR
 import static org.rauschig.jarchivelib.ArchiveFormat.ZIP
 import static org.rauschig.jarchivelib.CompressionType.GZIP
 
 /** Manages platform-specific SDK downloads. */
-enum SdkDownload {
-  WINDOWS('windows','zip'),
-  LINUX('linux', 'tgz'),
-  DARWIN('macosx', 'zip');
-
-  static SdkDownload get() {
-    switch (currentPlatform()) {
-      case PLATFORM_WINDOWS:
-        return WINDOWS
-      case PLATFORM_LINUX:
-        return LINUX
-      case PLATFORM_DARWIN:
-        return DARWIN
-      default:
-        throw new IllegalStateException("Unknown platform.")
-    }
-  }
-
-  final static SDK_VERSION_MAJOR = 24;
-
+class SdkDownload implements Downloader {
+  final String baseUrl
+  final String sdkMajorVersion
   final Logger log = Logging.getLogger SdkDownload
-  final String suffix
-  final String ext
+  final SdkPlatform platform
 
-  SdkDownload(String suffix, String ext) {
-    this.suffix = suffix
-    this.ext = ext
+  private String getExt() { return platform.ext }
+  private String getSuffix() { return platform.suffix }
+
+  SdkDownload(platform = SdkPlatform.get(), baseUrl = SdkResolver.DEFAULT_SDK_URL, sdkVersion = SdkResolver.DEFAULT_SDK_VERSION) {
+    this.platform = platform
+    this.baseUrl = baseUrl
+    this.sdkMajorVersion = sdkVersion
   }
 
   /** Download the SDK to {@code temp} and extract to {@code dest}. */
   void download(File dest) {
-    def url = "http://dl.google.com/android/android-sdk_r$SDK_VERSION_MAJOR-$suffix.$ext"
+    def url = "${baseUrl}/android-sdk_r${sdkMajorVersion}-${suffix}.${ext}"
     log.debug "Downloading SDK from $url."
 
     File temp = new File(dest.getParentFile(), 'android-sdk.temp')

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/SdkPlatform.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/SdkPlatform.groovy
@@ -1,0 +1,35 @@
+package com.jakewharton.sdkmanager.internal
+
+import static com.android.SdkConstants.PLATFORM_DARWIN
+import static com.android.SdkConstants.PLATFORM_LINUX
+import static com.android.SdkConstants.PLATFORM_UNKNOWN
+import static com.android.SdkConstants.PLATFORM_WINDOWS
+import static com.android.SdkConstants.currentPlatform
+
+enum SdkPlatform {
+  WINDOWS('windows','zip'),
+  LINUX('linux', 'tgz'),
+  DARWIN('macosx', 'zip');
+
+  static SdkPlatform get() {
+    switch (currentPlatform()) {
+      case PLATFORM_WINDOWS:
+        return WINDOWS
+      case PLATFORM_LINUX:
+        return LINUX
+      case PLATFORM_DARWIN:
+        return DARWIN
+      default:
+        throw new IllegalStateException("Unknown platform.")
+    }
+  }
+
+  final String suffix
+  final String ext
+
+  SdkPlatform(String suffix, String ext) {
+    this.suffix = suffix
+    this.ext = ext
+  }
+}
+

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/SdkResolver.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/SdkResolver.groovy
@@ -14,8 +14,14 @@ import static com.android.SdkConstants.currentPlatform
 class SdkResolver {
   static File resolve(Project project) {
     boolean isWindows = currentPlatform() == PLATFORM_WINDOWS
-    return new SdkResolver(project, new System.Real(), new Downloader.Real(), isWindows).resolve()
+    def baseUrl = project.hasProperty('sdkBaseUrl') ? project.property('sdkBaseUrl') : DEFAULT_SDK_URL
+    def sdkVersion = project.hasProperty('sdkVersion') ? project.property('sdkVersion') : DEFAULT_SDK_VERSION
+    Downloader realDownloader = new SdkDownload(SdkPlatform.get(), baseUrl, sdkVersion)
+    return new SdkResolver(project, new System.Real(), realDownloader, isWindows).resolve()
   }
+
+  static final String DEFAULT_SDK_URL = 'https://dl.google.com/android'
+  static final String DEFAULT_SDK_VERSION = '24.0.2'
 
   final Logger log = Logging.getLogger SdkResolver
   final Project project


### PR DESCRIPTION
This allows organizations to host the SDK archives locally and update the SDK archive version without having to modify the plugin code via optional gradle properties.