### PR TITLE
Make it possible to update SDK Tools by defining minSdkToolsVersion. Fixes issues #43 #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Change Log
 Version 1.2.0 *(In Development)*
 --------------------------------
 
+ * New: SDK Tools will be updated if version is older than defined with sdkManager.minSdkToolsVersion
+   in build.gradle:
+      sdkManager {
+         minSdkToolsVersion '24.3.4'
+      }
  * New: Support for the 1.2.x Android plugin.
  * New: Download r24.2 Android SDK.
 

--- a/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerExtension.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerExtension.groovy
@@ -3,4 +3,5 @@ package com.jakewharton.sdkmanager;
 class SdkManagerExtension {
   String emulatorVersion
   String emulatorArchitecture
+  String minSdkToolsVersion
 }

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/AndroidCommand.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/AndroidCommand.groovy
@@ -66,7 +66,7 @@ interface AndroidCommand {
 
       def result = ''
       output.split('----------').each {
-        if (it.contains(filter)) {
+        if (it.contains("\"$filter\"")) {
           result += it
         }
       }

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
@@ -17,6 +17,7 @@ import static com.android.SdkConstants.FD_PLATFORMS
 import static com.android.SdkConstants.FD_ADDONS
 import static com.android.SdkConstants.FD_PLATFORM_TOOLS
 import static com.android.SdkConstants.FD_SYSTEM_IMAGES
+import static com.android.SdkConstants.FD_TOOLS
 
 class PackageResolver {
   static void resolve(Project project, File sdk) {
@@ -59,12 +60,63 @@ class PackageResolver {
   }
 
   def resolve() {
+    resolveSdkTools()
     resolveBuildTools()
     resolvePlatformTools()
     resolveCompileVersion()
     resolveSupportLibraryRepository()
     resolvePlayServiceRepository()
     resolveEmulator()
+  }
+
+  def resolveSdkTools() {
+    def minSdkToolsVersion = project.sdkManager.minSdkToolsVersion
+    if (minSdkToolsVersion == null) {
+      log.debug 'No minSdkToolsVersion defined'
+      return
+    }
+    log.debug "Found minSdkToolsVersion: $minSdkToolsVersion"
+
+    def sdkToolsDir = new File(sdk, FD_TOOLS)
+    def sdkToolsVersion = getPackageRevision(sdkToolsDir)
+    log.debug "Found sdkToolsVersion: $sdkToolsVersion"
+
+    def minSdkToolsRevision = FullRevision.parseRevision(minSdkToolsVersion)
+    def sdkToolsRevision = FullRevision.parseRevision(sdkToolsVersion)
+    def needsDownload = sdkToolsRevision < minSdkToolsRevision
+
+    if (!needsDownload) {
+      log.debug "SDK tools are up to date."
+      return
+    }
+
+    def sdkToolsPackage = "tools"
+    def currentSdkToolsInfo = androidCommand.list sdkToolsPackage
+    if (currentSdkToolsInfo == null || currentSdkToolsInfo.isEmpty()) {
+      throw new StopExecutionException('Could not get the current SDK tools revision.')
+    }
+
+    def matcher = Pattern.compile("revision\\ (.+)").matcher(currentSdkToolsInfo)
+    if (!matcher.find()) {
+      throw new StopExecutionException("Could not find the current SDK tools revision." +
+              " currentSdkToolsInfo: $currentSdkToolsInfo")
+    }
+
+    def currentSdkToolsVersion = matcher.group(1)
+    log.debug "currentSdkToolsVersion: $currentSdkToolsVersion"
+
+    def currentSdkToolsRevision = FullRevision.parseRevision(currentSdkToolsVersion)
+    if (currentSdkToolsRevision < minSdkToolsRevision) {
+      throw new StopExecutionException("Currently available SDK tools version($currentSdkToolsVersion)" +
+              " is smaller than defined in minSdkToolsVersion: $minSdkToolsVersion")
+    }
+
+    log.lifecycle "SDK tools $sdkToolsVersion outdated. Downloading update..."
+
+    def code = androidCommand.update sdkToolsPackage
+    if (code != 0) {
+      throw new StopExecutionException("SDK tools download failed with code $code.")
+    }
   }
 
   def resolveBuildTools() {
@@ -223,21 +275,7 @@ class PackageResolver {
       needsDownload = true
       log.lifecycle "Emulator $emulatorVersion $emulatorArchitecture missing. Downloading..."
     } else {
-      def emulatorPropertiesFile = new File(emulatorDir, 'source.properties')
-      if (!emulatorPropertiesFile.canRead()) {
-        emulatorPropertiesFile = new File(alternativeEmulatorDir, 'source.properties')
-        if (!emulatorPropertiesFile.canRead()) {
-          throw new StopExecutionException('Could not read ' + emulatorPropertiesFile.absolutePath)
-        }
-      }
-
-      def emulatorProperties = new Properties()
-      emulatorProperties.load(new FileInputStream(emulatorPropertiesFile))
-      def emulatorRevision = emulatorProperties.getProperty('Pkg.Revision')
-      if (emulatorRevision == null) {
-        throw new StopExecutionException('Could not get the installed emulator revision for ' +
-            emulatorPackage)
-      }
+      def emulatorRevision = getPackageRevision(emulatorDir, alternativeEmulatorDir)
 
       def currentEmulatorInfo = androidCommand.list emulatorPackage
       if (currentEmulatorInfo == null || currentEmulatorInfo.isEmpty()) {
@@ -264,6 +302,24 @@ class PackageResolver {
             "Emulator $emulatorVersion $emulatorArchitecture download failed with code $code.")
       }
     }
+  }
+
+  def getPackageRevision(File[] packageDirs) {
+    def propertiesFileName = 'source.properties'
+    def propertiesFile = packageDirs.collect { new File(it, propertiesFileName) }.find { it.canRead() }
+    if (propertiesFile == null) {
+      throw new StopExecutionException("Could not read '$propertiesFileName' from: $packageDirs")
+    }
+
+    def properties = new Properties()
+    properties.load(new FileInputStream(propertiesFile))
+    def revision = properties.getProperty('Pkg.Revision')
+    if (revision == null) {
+      throw new StopExecutionException("Could not read the revision from: ${propertiesFile.absolutePath}")
+    }
+
+    log.debug "Found revision for package ${propertiesFile.absolutePath}: $revision"
+    return revision
   }
 
   def findDependenciesWithGroup(String group) {

--- a/src/test/fixtures/outdated-sdk-tools/.android-sdk/tools/source.properties
+++ b/src/test/fixtures/outdated-sdk-tools/.android-sdk/tools/source.properties
@@ -1,0 +1,8 @@
+### Android Tool: Source of this archive.
+#Thu Sep 24 18:29:52 EEST 2015
+Archive.HostOs=macosx
+Pkg.License=To get started with the Android SDK, you must agree to the following terms and conditions.\n
+Pkg.LicenseRef=android-sdk-license
+Pkg.Revision=22.6
+Pkg.SourceUrl=https\://dl-ssl.google.com/android/repository/repository-10.xml
+Platform.MinPlatformToolsRev=20

--- a/src/test/fixtures/outdated-sdk-tools/project/src/main/AndroidManifest.xml
+++ b/src/test/fixtures/outdated-sdk-tools/project/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    android:versionName="1.0"
+    package="com.example.sdkmanager"
+    />

--- a/src/test/fixtures/up-to-date-sdk-tools/.android-sdk/tools/source.properties
+++ b/src/test/fixtures/up-to-date-sdk-tools/.android-sdk/tools/source.properties
@@ -1,0 +1,8 @@
+### Android Tool: Source of this archive.
+#Thu Sep 24 18:29:52 EEST 2015
+Archive.HostOs=macosx
+Pkg.License=To get started with the Android SDK, you must agree to the following terms and conditions.\n
+Pkg.LicenseRef=android-sdk-license
+Pkg.Revision=24.3.4
+Pkg.SourceUrl=https\://dl-ssl.google.com/android/repository/repository-10.xml
+Platform.MinPlatformToolsRev=20

--- a/src/test/fixtures/up-to-date-sdk-tools/project/src/main/AndroidManifest.xml
+++ b/src/test/fixtures/up-to-date-sdk-tools/project/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    android:versionName="1.0"
+    package="com.example.sdkmanager"
+    />

--- a/src/test/groovy/com/jakewharton/sdkmanager/util/RecordingAndroidCommand.groovy
+++ b/src/test/groovy/com/jakewharton/sdkmanager/util/RecordingAndroidCommand.groovy
@@ -16,10 +16,13 @@ final class RecordingAndroidCommand extends ArrayList<String> implements Android
 
   @Override String list(String filter) {
     add("list -a -e" as String)
-    return  "id: 55 or \"sys-img-armeabi-v7a-android-19\"\n" +
-            "     Type: SystemImage\n" +
-            "     Desc: Android SDK Platform 4.4.2\n" +
-            "           Revision 2\n" +
-            "           Requires SDK Platform Android API 19\n"
+    return "id: 1 or \"tools\"\n" +
+           "     Type: Tool\n" +
+           "     Desc: Android SDK Tools, revision 24.3.4\n" +
+           "id: 55 or \"sys-img-armeabi-v7a-android-19\"\n" +
+           "     Type: SystemImage\n" +
+           "     Desc: Android SDK Platform 4.4.2\n" +
+           "           Revision 2\n" +
+           "           Requires SDK Platform Android API 19\n"
   }
 }


### PR DESCRIPTION
Now for update Android SDK Tools just define necessary minSdkToolsVersion in your build.gradle, for example:

sdkManager {
    minSdkToolsVersion '24.3.4'
}