### PR TITLE
Allow plugin to work with Android Gradle plugin 2.0.0-alpha1

### DIFF
--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
@@ -1,6 +1,5 @@
 package com.jakewharton.sdkmanager.internal
 
-import com.android.sdklib.repository.FullRevision
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency


### PR DESCRIPTION
Remove unused `FullRevision` import.

This class was removed from the Android Gradle plugin, so starting a build with version 2.0 of the plugin would throw an exception during initialisation.