### PR TITLE
Allow emulator download on non Android projects

### DIFF
--- a/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerPlugin.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerPlugin.groovy
@@ -36,12 +36,14 @@ class SdkManagerPlugin implements Plugin<Project> {
     // Defer resolving SDK package dependencies until after the model is finalized.
     project.afterEvaluate {
       if (!hasAndroidPlugin(project)) {
-        log.debug 'No Android plugin detecting. Skipping package resolution.'
-        return
-      }
-
-      time "Package resolve", {
-        PackageResolver.resolve project, sdk
+        log.debug 'No Android plugin, attempting emulator.'
+        time "Package resolve emulator", {
+          PackageResolver.resolveEmulator project, sdk
+        }
+      } else {
+        time "Package resolve", {
+          PackageResolver.resolve project, sdk
+        }
       }
     }
   }

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
@@ -21,6 +21,10 @@ class PackageResolver {
   static void resolve(Project project, File sdk) {
     new PackageResolver(project, sdk, new AndroidCommand.Real(sdk, new System.Real())).resolve()
   }
+  
+  static void resolveEmulator(Project project, File sdk) {
+    new PackageResolver(project, sdk, new AndroidCommand.Real(sdk, new System.Real())).resolveEmulator()
+  }
 
   static boolean folderExists(File folder) {
     return folder.exists() && folder.list().length != 0


### PR DESCRIPTION
I have a separate project for my acceptance tests running selenium. It's strictly a java project which starts an emulator and executes the tests. 

I would like to be able to use sdk-manager-plugin to resolve and download the emulator provided the configuration `sdkManager.emulatorVersion` as documented. Downloading the emulator has not dependencies on an Android project.
