### PR TITLE
Do not proceed when configuration step has thrown

### DIFF
--- a/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerPlugin.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerPlugin.groovy
@@ -34,7 +34,11 @@ class SdkManagerPlugin implements Plugin<Project> {
     }
 
     // Defer resolving SDK package dependencies until after the model is finalized.
-    project.afterEvaluate {
+    project.afterEvaluate { ignored, state ->
+      if (state.failure) {
+        return
+      }
+      
       if (!hasAndroidPlugin(project)) {
         log.debug 'No Android plugin detecting. Skipping package resolution.'
         return


### PR DESCRIPTION
Do not attempt SDK resolution after exception has been thrown in evaluation phase. Otherwise, when `afterEvaluate` code fails (naturally, the evaluation was not completed!), the actual configuration exception gets swallowed without a trace.