### PR TITLE
Update to PR #87 ("Make it possible to update SDK Tools ..")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Version 1.5.0 *(In Development)*
 --------------------------------
 
  * New: Support for the 1.5.x Android plugin.
+ * New: SDK Tools will be updated if version is older than defined with sdkManager.minSdkToolsVersion
+   in build.gradle:
+      sdkManager {
+         minSdkToolsVersion '24.3.4'
+      }
  * New: Download r24.2 Android SDK.
 
 

--- a/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerExtension.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/SdkManagerExtension.groovy
@@ -3,4 +3,5 @@ package com.jakewharton.sdkmanager;
 class SdkManagerExtension {
   String emulatorVersion
   String emulatorArchitecture
+  String minSdkToolsVersion
 }

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/AndroidCommand.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/AndroidCommand.groovy
@@ -66,7 +66,7 @@ interface AndroidCommand {
 
       def result = ''
       output.split('----------').each {
-        if (it.contains(filter)) {
+        if (it.contains("\"$filter\"")) {
           result += it
         }
       }

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/PackageResolver.groovy
@@ -80,8 +80,8 @@ class PackageResolver {
     def sdkToolsVersion = getPackageRevision(sdkToolsDir)
     log.debug "Found sdkToolsVersion: $sdkToolsVersion"
 
-    def minSdkToolsRevision = FullRevision.parseRevision(minSdkToolsVersion)
-    def sdkToolsRevision = FullRevision.parseRevision(sdkToolsVersion)
+    def minSdkToolsRevision = VersionMatcher.parse(minSdkToolsVersion)
+    def sdkToolsRevision = VersionMatcher.parse(sdkToolsVersion)
     def needsDownload = sdkToolsRevision < minSdkToolsRevision
 
     if (!needsDownload) {
@@ -104,7 +104,7 @@ class PackageResolver {
     def currentSdkToolsVersion = matcher.group(1)
     log.debug "currentSdkToolsVersion: $currentSdkToolsVersion"
 
-    def currentSdkToolsRevision = FullRevision.parseRevision(currentSdkToolsVersion)
+    def currentSdkToolsRevision = VersionMatcher.parse(currentSdkToolsVersion)
     if (currentSdkToolsRevision < minSdkToolsRevision) {
       throw new StopExecutionException("Currently available SDK tools version($currentSdkToolsVersion)" +
               " is smaller than defined in minSdkToolsVersion: $minSdkToolsVersion")

--- a/src/main/groovy/com/jakewharton/sdkmanager/internal/VersionMatcher.groovy
+++ b/src/main/groovy/com/jakewharton/sdkmanager/internal/VersionMatcher.groovy
@@ -1,0 +1,62 @@
+package com.jakewharton.sdkmanager.internal
+
+import org.gradle.api.tasks.StopExecutionException
+
+import java.util.regex.Pattern
+
+class VersionMatcher implements Comparable<VersionMatcher> {
+  private final int major
+  private final int minor
+  private final int micro
+  private final int preview
+
+  private static final Pattern VERSION_PATTERN =
+      Pattern.compile("\\s*([0-9]+)(?:\\.([0-9]+)(?:\\.([0-9]+))?)?\\s*(?:rc([0-9]+))?\\s*")
+
+  public VersionMatcher(int major, int minor, int micro, int preview) {
+    this.major = major
+    this.minor = minor
+    this.micro = micro
+    this.preview = preview
+  }
+
+  public static VersionMatcher parse(String version) {
+    def m = VERSION_PATTERN.matcher(version)
+    if (m == null || !m.matches()) {
+      throw new StopExecutionException('Version string mismatched')
+    }
+
+    int major = Integer.parseInt(m.group(1))
+    String s = m.group(2)
+    int minor = s == null ? 0 : Integer.parseInt(s)
+    s = m.group(3)
+    int micro = s == null ? 0 : Integer.parseInt(s)
+    s = m.group(4)
+    // Something that isn't a release candidate is newer than something that is
+    // e.g. "18.0.0 rc1" < "18.0.0"
+    int preview = s == null ? Integer.MAX_VALUE : Integer.parseInt(s)
+
+    return new VersionMatcher(major, minor, micro, preview)
+  }
+
+  @Override
+  public int compareTo(VersionMatcher rhs) {
+    int delta = major - rhs.major
+    if (delta != 0) {
+      return delta
+    }
+
+    delta = minor - rhs.minor
+    if (delta != 0) {
+      return delta
+    }
+
+    delta = micro - rhs.micro;
+    if (delta != 0) {
+      return delta
+    }
+
+    delta = preview - rhs.preview;
+    return delta
+  }
+}

--- a/src/test/fixtures/outdated-sdk-tools/.android-sdk/tools/source.properties
+++ b/src/test/fixtures/outdated-sdk-tools/.android-sdk/tools/source.properties
@@ -1,0 +1,8 @@
+### Android Tool: Source of this archive.
+#Thu Sep 24 18:29:52 EEST 2015
+Archive.HostOs=macosx
+Pkg.License=To get started with the Android SDK, you must agree to the following terms and conditions.\n
+Pkg.LicenseRef=android-sdk-license
+Pkg.Revision=22.6
+Pkg.SourceUrl=https\://dl-ssl.google.com/android/repository/repository-10.xml
+Platform.MinPlatformToolsRev=20

--- a/src/test/fixtures/outdated-sdk-tools/project/src/main/AndroidManifest.xml
+++ b/src/test/fixtures/outdated-sdk-tools/project/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    android:versionName="1.0"
+    package="com.example.sdkmanager"
+    />

--- a/src/test/fixtures/up-to-date-sdk-tools/.android-sdk/tools/source.properties
+++ b/src/test/fixtures/up-to-date-sdk-tools/.android-sdk/tools/source.properties
@@ -1,0 +1,8 @@
+### Android Tool: Source of this archive.
+#Thu Sep 24 18:29:52 EEST 2015
+Archive.HostOs=macosx
+Pkg.License=To get started with the Android SDK, you must agree to the following terms and conditions.\n
+Pkg.LicenseRef=android-sdk-license
+Pkg.Revision=24.3.4
+Pkg.SourceUrl=https\://dl-ssl.google.com/android/repository/repository-10.xml
+Platform.MinPlatformToolsRev=20

--- a/src/test/fixtures/up-to-date-sdk-tools/project/src/main/AndroidManifest.xml
+++ b/src/test/fixtures/up-to-date-sdk-tools/project/src/main/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    android:versionName="1.0"
+    package="com.example.sdkmanager"
+    />

--- a/src/test/groovy/com/jakewharton/sdkmanager/util/RecordingAndroidCommand.groovy
+++ b/src/test/groovy/com/jakewharton/sdkmanager/util/RecordingAndroidCommand.groovy
@@ -16,10 +16,13 @@ final class RecordingAndroidCommand extends ArrayList<String> implements Android
 
   @Override String list(String filter) {
     add("list -a -e" as String)
-    return  "id: 55 or \"sys-img-armeabi-v7a-android-19\"\n" +
-            "     Type: SystemImage\n" +
-            "     Desc: Android SDK Platform 4.4.2\n" +
-            "           Revision 2\n" +
-            "           Requires SDK Platform Android API 19\n"
+    return "id: 1 or \"tools\"\n" +
+           "     Type: Tool\n" +
+           "     Desc: Android SDK Tools, revision 24.3.4\n" +
+           "id: 55 or \"sys-img-armeabi-v7a-android-19\"\n" +
+           "     Type: SystemImage\n" +
+           "     Desc: Android SDK Platform 4.4.2\n" +
+           "           Revision 2\n" +
+           "           Requires SDK Platform Android API 19\n"
   }
 }


### PR DESCRIPTION
Updated version of https://github.com/JakeWharton/sdk-manager-plugin/pull/87 to resolve merge conflicts with `master` and thereby support newest versions etc.

Quoting @rustmonster:
Make it possible to update SDK Tools by defining `minSdkToolsVersion`. Fixes issues #43 #14
Now to update Android SDK Tools just define necessary minSdkToolsVersion in your build.gradle, for example:
`sdkManager {
  minSdkToolsVersion '24.3.4'
}`
